### PR TITLE
[v2] PES mode Encapsulation

### DIFF
--- a/src/libtsduck/tsPacketEncapsulation.cpp
+++ b/src/libtsduck/tsPacketEncapsulation.cpp
@@ -42,6 +42,8 @@ const size_t ts::PacketEncapsulation::DEFAULT_MAX_BUFFERED_PACKETS;
 
 ts::PacketEncapsulation::PacketEncapsulation(PID pidOutput, const PIDSet& pidInput, PID pcrReference) :
     _packing(false),
+    _packDistance(-1),
+    _pesmode(0),
     _pidOutput(pidOutput),
     _pidInput(pidInput),
     _pcrReference(pcrReference),
@@ -53,6 +55,7 @@ ts::PacketEncapsulation::PacketEncapsulation(PID pidOutput, const PIDSet& pidInp
     _insertPCR(false),
     _ccOutput(0),
     _lastCC(),
+    _lateDistance(0),
     _lateMaxPackets(DEFAULT_MAX_BUFFERED_PACKETS),
     _lateIndex(0),
     _latePackets()
@@ -67,6 +70,8 @@ ts::PacketEncapsulation::PacketEncapsulation(PID pidOutput, const PIDSet& pidInp
 void ts::PacketEncapsulation::reset(PID pidOutput, const PIDSet& pidInput, PID pcrReference)
 {
     _packing = false;
+    _packDistance = -1;
+    _pesmode = 0;
     _pidOutput = pidOutput;
     _pidInput = pidInput;
     _pcrReference = pcrReference;
@@ -74,6 +79,7 @@ void ts::PacketEncapsulation::reset(PID pidOutput, const PIDSet& pidInput, PID p
     _currentPacket = 0;
     _ccOutput = 0;
     _lastCC.clear();
+    _lateDistance = 0;
     _lateIndex = 0;
     _latePackets.clear();
     resetPCR();
@@ -91,6 +97,7 @@ void ts::PacketEncapsulation::setOutputPID(PID pid)
         // Reset encapsulation.
         _ccOutput = 0;
         _lastCC.clear();
+        _lateDistance = 0;
         _lateIndex = 0;
         _latePackets.clear();
     }
@@ -211,6 +218,13 @@ bool ts::PacketEncapsulation::processPacket(TSPacket& pkt)
         status = false;
     }
 
+    // Increase the counter of the distance with each incoming packet.
+    _lateDistance++;
+
+    // We need to guarantee the limits of all packages.
+    // When the buffer is empty we alredy set the late pointer to the first byte after 0x47.
+    if (_lateIndex < 1) _lateIndex = 1;
+
     // If this packet is part of the input set, place it in the "late" queue.
     // Note that a packet always need to go into the queue, even if the queue
     // is empty because no input packet can fit into an output packet. At least
@@ -232,6 +246,12 @@ bool ts::PacketEncapsulation::processPacket(TSPacket& pkt)
         pid = PID_NULL;
     }
 
+    // Check PES mode support
+    if (_pesmode > 2) {
+        _lastError.assign(u"PES mode %u not implemented!", _pesmode);
+        status = false;
+    }
+
     // Replace input or null packets.
     if (pid == PID_NULL && !_latePackets.empty()) {
 
@@ -247,9 +267,13 @@ bool ts::PacketEncapsulation::processPacket(TSPacket& pkt)
         //   -4 => TS header.
         //   -8 => Adaptation field in case of PCR: 1-byte AF size, 1-byte flags, 6-byte PCR.
         //   -1 => Pointer field, first byte of payload (not always, but very often).
+        // -26|27 => PES size (when PES mode is enabled).
         // We insert a packet all the time if packing is off.
         // Otherwise, we insert a packet when there is enough data to fill it.
-        if (!_packing || addBytes >= PKT_SIZE - (addPCR ? 12 : 4) - 1) {
+        bool packout = !_packing;
+        if (_packing && _packDistance > 0 && _lateDistance > _packDistance)
+            packout = true;
+        if (packout || addBytes >= PKT_SIZE - (addPCR ? 12 : 4) - 1) {
 
             // Build the new packet.
             pkt.init(_pidOutput, _ccOutput);
@@ -271,26 +295,116 @@ bool ts::PacketEncapsulation::processPacket(TSPacket& pkt)
                 _insertPCR = false;
             }
 
+            // Increase the header size to the limit of the selected PES mode:
+            //  PES mode 1: 127+9+16+1 max payload
+            //  PES mode 2: no limit
+            if (_pesmode == 1 && pkt.getPayloadSize() > 153) {
+                pkt.setPayloadSize(153);
+            }
+
+            // How many bytes consumes de PES encapsulation, based on this calculus:
+            //   26|27 bytes =
+            //          9 bytes PES header;
+            //       + 16 bytes KLVA UL key;
+            //       +  1 byte with BER short mode | 2 bytes with BER long mode.
+            //   and 0 when PES mode is OFF.
+            const uint8_t pes_header = _pesmode > 0 ? (addBytes <= 127 || pkt.getPayloadSize() <= 153 ? 26 : 27) : 0;
+
             // If there are less "late" bytes than the output payload size, enlarge the adaptation field
             // with stuffing. Note that if there is so few bytes in the only "late" packet, this cannot
             // be the beginning of a packet and there will be no pointer field.
-            if (_latePackets.size() == 1 && _lateIndex > pkt.getHeaderSize()) {
-                pkt.setPayloadSize(PKT_SIZE - _lateIndex);
+            if (_latePackets.size() == 1 && _lateIndex > (pes_header + pkt.getHeaderSize())) {
+                pkt.setPayloadSize(PKT_SIZE - _lateIndex + pes_header);
             }
 
             // Index in pkt where we write data. Start at beginning of payload.
             size_t pktIndex = pkt.getHeaderSize();
 
+            // When PES mode is ON add here the envelope before the data/payload
+            uint8_t pes_pointer = 0; // Indirect reference for futher completion
+            if (pes_header > 0) {
+
+                // Fill the PES Header
+
+                pkt.b[pktIndex++] = 0x00; // PES start code prefix
+                pkt.b[pktIndex++] = 0x00;
+                pkt.b[pktIndex++] = 0x01;
+
+                pkt.b[pktIndex++] = 0xBD; // Stream_id == Pivate_Stream_1
+
+                pkt.b[pktIndex++] = 0x00; // PES packet length (2 bytes)
+                pkt.b[pktIndex++] = 0x00; // Pending to complete at end (**)
+
+                pes_pointer = pktIndex;   // Store for reference
+
+                pkt.b[pktIndex++] = 0x84; // Header flags
+                pkt.b[pktIndex++] = 0x00; // Header flags
+                pkt.b[pktIndex++] = 0x00; // Length of remaining optional fields
+
+                // Fill the KLVA Data
+
+                // >>> (K)ey
+                // UL Used: 060E2B34.01010101.0F010800.0F0F0F0F
+                // It's an Unique ID value in the testing range.
+                pkt.b[pktIndex++] = 0x06;
+                pkt.b[pktIndex++] = 0x0e;
+                pkt.b[pktIndex++] = 0x2b;
+                pkt.b[pktIndex++] = 0x34;
+
+                pkt.b[pktIndex++] = 0x01;
+                pkt.b[pktIndex++] = 0x01;
+                pkt.b[pktIndex++] = 0x01;
+                pkt.b[pktIndex++] = 0x01;
+
+                pkt.b[pktIndex++] = 0x0f;
+                pkt.b[pktIndex++] = 0x01;
+                pkt.b[pktIndex++] = 0x08;
+                pkt.b[pktIndex++] = 0x00;
+
+                pkt.b[pktIndex++] = 0x0f;
+                pkt.b[pktIndex++] = 0x0f;
+                pkt.b[pktIndex++] = 0x0f;
+                pkt.b[pktIndex++] = 0x0f; // 0x1f when equivalent PUSI flag is set
+
+                // >>> (L)ength
+                uint8_t payload_size = PKT_SIZE - pktIndex - 1;
+                assert(payload_size > 0);
+                if (payload_size > 127) {
+                    pkt.b[pktIndex++] = 0x81; // Long flag with size length = 1
+                    payload_size--;
+                }
+                pkt.b[pktIndex++] = payload_size; // Final size of data/payload
+
+                // Update the remaining value of the PES packet length (**)
+                pkt.b[pes_pointer-1] = uint8_t(PKT_SIZE - pes_pointer);
+
+                // >>> (V)alue
+                // At this point the PES packet is fully filled and only remains the payload
+                assert(pktIndex < PKT_SIZE);
+
+                // In PES mode any packet is an unique PES packet, so set the Payload Unit Start
+                pkt.setPUSI();
+                // When using the PES encapsulation the PUSI flag is mapped
+                // at bit 0x10 in the last byte of the UL Key.
+            }
+
             // Insert PUSI and pointer field when necessary.
             if (_lateIndex == 1) {
                 // We immediately start with the start of a packet.
-                pkt.setPUSI();
+                // Note: The flag is different in the PES mode!
+                if (_pesmode > 0)
+                    pkt.b[pes_pointer+18] |= 0x10;
+                else
+                    pkt.setPUSI();
                 pkt.b[pktIndex++] = 0; // pointer field
             }
             else if (_lateIndex > pktIndex + 1 && _latePackets.size() > 1) {
                 // The remaining bytes in the first packet are less than the output payload,
                 // we will start a new packet in this payload.
-                pkt.setPUSI();
+                if (_pesmode > 0)
+                    pkt.b[pes_pointer+18] |= 0x10;
+                else
+                    pkt.setPUSI();
                 pkt.b[pktIndex++] = uint8_t(PKT_SIZE - _lateIndex); // pointer field
             }
 

--- a/src/libtsduck/tsPacketEncapsulation.h
+++ b/src/libtsduck/tsPacketEncapsulation.h
@@ -47,8 +47,8 @@ namespace ts {
     //! this is a subset of the features of T2-MI but much more lightweight
     //! and significantly faster to process.
     //!
-    //! Encapsulation format
-    //! --------------------
+    //! Encapsulation format (plain)
+    //! ----------------------------
     //! In the output elementary stream (ES), all input TS packets are
     //! contiguous, without encapsulation. The initial 0x47 synchronization
     //! byte is removed. Only the remaining 187 bytes are encapsulated.
@@ -64,6 +64,58 @@ namespace ts {
     //! is slightly larger than the input packets. The input streams must
     //! contain a few null packets to absorb the extra output packets. For
     //! this reason, null packets (PID 0x1FFF) are never encapsulated.
+    //!
+    //! Encapsulation format (PES)
+    //! --------------------------
+    //! When selecting the PES encapsulation the same plain elementary
+    //! stream is used, but with a PES envelope. This reduces the payload
+    //! size, but makes the outer encapsulation more transparent. The full
+    //! overhead is around 14% of more data.
+    //!
+    //! The PES envelope uses a KLVA SMPTE-336M encapsulation to insert the
+    //! inner payload into one private (testing) key. Each TS packet contains
+    //! only one key, with a size no larger than the payload of one TS packet.
+    //! So each PES packet fits into a single TS packet.
+    //!
+    //! The SMPTE-336M encapsulation is the asynchrouns one. So no PTS
+    //! marks are used, and the payload size is larger.
+    //!
+    //! Two variant strategies are implemented. The FIXED mode uses the
+    //! short (7bit) BER encoding. This limits the PES payload to a maximum
+    //! of 127 bytes. And the adaptation field of the outer packet is
+    //! enlarged with some stuff. However, the advantage is that the PES
+    //! is sufficient small to include more data in the outer TS packet.
+    //! This reduces the possibility than some external processing will
+    //! split the outer packet in two to accomodate the entire PES data.
+    //!
+    //! The VARIABLE mode does not imposses this restriction, and outer
+    //! packets are filled as maximum. The drawback is that some times
+    //! the long form of BER encoding is used with two bytes and others
+    //! the short form with one byte. Futhermore, this increases the chances
+    //! that some external procesing ocuppies two outer packets for the
+    //! same inner PES packet. Still, support for those split PES packets
+    //! is included. The only requirement is that the 26|27 PES+KLVA header
+    //! is inserted in the first packet (with PUSI on). The remaining
+    //! payload can be distributed in thge following TS packets.
+    //!
+    //! The PES envelope has an overhead of 26 or 27 bytes based on:
+    //!   9 bytes for the PES header.
+    //!  16 bytes for the UL key
+    //! 1|2 bytes for the payload size (BER short or long format)
+    //!
+    //! In order to correctly identify the encapsulated PES stream is
+    //! recommended to include in the PMT table a format identifier
+    //! descriptor for "KLVA" (0x4B4C5641); and use the Private Type (0x06)
+    //! for the stream type.
+    //!  Example:
+    //!   "tsp ... \                                                     "
+    //!   " -P encap -o 7777 --pes-mode ... \                            "
+    //!   " -P pmt -s 100 -a 7777/0x06 --add-programinfo-id 0x4B4C5641 \ "
+    //!   " ...                                                          "
+    //!   where the target pid is 7777 and the attached service is 100.
+    //!
+    //! References:
+    //! https://impleotv.com/2017/02/17/klv-encoded-metadata-in-stanag-4609-streams/
     //!
     class TSDUCKDLL PacketEncapsulation
     {
@@ -189,7 +241,15 @@ namespace ts {
         //! are emitted only when they are full.
         //! @param [in] on Packing mode.
         //!
-        void setPacking(bool on) { _packing = on; }
+        void setPacking(bool on, size_t limit) { _packing = on; _packDistance = limit; }
+         //!
+        //! Set PES mode.
+        //! Enbles the PES mode encapsulation (disabled by default).
+        //! Accepted values are:
+        //! 0=disabled; 1=fixed; 2=variable.
+        //! @param [in] on PES mode.
+        //!
+        void setPES(size_t mode) { _pesmode = mode; }
 
     private:
         typedef std::map<PID,uint8_t> PIDCCMap;  // map of continuity counters, indexed by PID
@@ -197,6 +257,8 @@ namespace ts {
         typedef std::deque<TSPacketPtr> TSPacketPtrQueue;
 
         bool             _packing;         // Packing mode.
+        size_t           _packDistance;    // Maximum distance between inner packets.
+        size_t           _pesmode;         // PES mode selected.
         PID              _pidOutput;       // Output PID.
         PIDSet           _pidInput;        // Input PID's to encapsulate.
         PID              _pcrReference;    // Insert PCR's based on this reference PID.
@@ -208,6 +270,7 @@ namespace ts {
         bool             _insertPCR;       // Insert a PCR in next output packet.
         uint8_t          _ccOutput;        // Continuity counter in output PID.
         PIDCCMap         _lastCC;          // Continuity counter by PID.
+        size_t           _lateDistance;    // Distance from the last packet.
         size_t           _lateMaxPackets;  // Maximum number of packets in _latePackets.
         size_t           _lateIndex;       // Index in first late packet.
         TSPacketPtrQueue _latePackets;     // Packets to insert later.

--- a/src/libtsduck/tsVersion.h
+++ b/src/libtsduck/tsVersion.h
@@ -44,4 +44,4 @@
 //!
 //! TSDuck commit number (automatically updated by Git hooks).
 //!
-#define TS_COMMIT 1064
+#define TS_COMMIT 1068

--- a/src/tsplugins/tsplugin_encap.cpp
+++ b/src/tsplugins/tsplugin_encap.cpp
@@ -56,10 +56,12 @@ namespace ts {
     private:
         bool                _ignoreErrors;  // Ignore encapsulation errors.
         bool                _pack;          // Outer packet packing option.
+        size_t              _packLimit;     // Max limit distance.
         size_t              _maxBuffered;   // Max buffered packets.
         PID                 _pidOutput;     // Output PID.
         PID                 _pidPCR;        // PCR reference PID.
         PIDSet              _pidsInput;     // Input PID's.
+        size_t              _modePES;       // Enable PES mode and select type.
         PacketEncapsulation _encap;         // Encapsulation engine.
 
         // Inaccessible operations
@@ -81,10 +83,12 @@ ts::EncapPlugin::EncapPlugin(TSP* tsp_) :
     ProcessorPlugin(tsp_, u"Encapsulate packets from several PID's into one single PID", u"[options]"),
     _ignoreErrors(false),
     _pack(false),
+    _packLimit(0),
     _maxBuffered(0),
     _pidOutput(PID_NULL),
     _pidPCR(PID_NULL),
     _pidsInput(),
+    _modePES(0),
     _encap()
 {
     option(u"ignore-errors", 'i');
@@ -112,18 +116,27 @@ ts::EncapPlugin::EncapPlugin(TSP* tsp_) :
          u"Specify a reference PID containing PCR's. The output PID will contain PCR's, "
          u"based on the same clock. By default, the output PID does not contain any PCR.");
 
-    option(u"pack");
+    option(u"pack", 0, INTEGER, 0, 1, 0, UNLIMITED_VALUE);
     help(u"pack",
          u"Emit outer packets when they are full only. By default, emit outer packets "
          u"as soon as possible, when null packets are available on input. With the default "
          u"behavior, inner packets are decapsulated with a better time accuracy, at the expense "
-         u"of a higher bitrate of the outer PID when there are many null packets in input.");
+         u"of a higher bitrate of the outer PID when there are many null packets in input. "
+         u"You can limit the distance between packets adding a positive value. "
+         u"With a 0 value the distance is disabled (=unlimited). "
+         u"The value 1 is equivalent to not use the pack mode.");
 
     option(u"pid", 'p', INTEGER, 1, UNLIMITED_COUNT, 0, PID_NULL - 1);
     help(u"pid", u"pid1[-pid2]",
          u"Specify an input PID or range of PID's to encapsulate. "
          u"Several --pid options can be specified. "
          u"The null PID 0x1FFF cannot be encapsulated.");
+
+    option(u"pes-mode", 0, INTEGER, 0, 1, 0, 2);
+    help(u"pes-mode", u"mode",
+         u"Enable PES mode encapsulation. "
+         u"Modes available are: "
+         u"0=disabled; 1=fixed; 2=variable.");
 }
 
 
@@ -135,9 +148,11 @@ bool ts::EncapPlugin::getOptions()
 {
     _ignoreErrors = present(u"ignore-errors");
     _pack = present(u"pack");
+    _packLimit = intValue<size_t>(u"pack", 0);
     _maxBuffered = intValue<size_t>(u"max-buffered-packets", PacketEncapsulation::DEFAULT_MAX_BUFFERED_PACKETS);
     _pidOutput = intValue<PID>(u"output-pid", PID_NULL);
     _pidPCR = intValue<PID>(u"pcr-pid", PID_NULL);
+    _modePES = intValue<size_t>(u"pes-mode", 0);
     getIntValues(_pidsInput, u"pid");
 
     return true;
@@ -151,7 +166,8 @@ bool ts::EncapPlugin::getOptions()
 bool ts::EncapPlugin::start()
 {
     _encap.reset(_pidOutput, _pidsInput, _pidPCR);
-    _encap.setPacking(_pack);
+    _encap.setPacking(_pack, _packLimit);
+    _encap.setPES(_modePES);
     _encap.setMaxBufferedPackets(_maxBuffered);
     return true;
 }


### PR DESCRIPTION
This is a new version of the PES mode Encapsulation.
Changes:
- Uses new function `setPayloadSize`, so the encapsulation function is more simple.
- Fixed crash when enabling `--pcr-pid`.
