### PR TITLE
Missing include

### DIFF
--- a/src/tstools/tsdump.cpp
+++ b/src/tstools/tsdump.cpp
@@ -35,6 +35,7 @@
 #include "tsMain.h"
 #include "tsTSPacket.h"
 #include "tsPagerArgs.h"
+#include "tsUString.h"
 TSDUCK_SOURCE;
 
 


### PR DESCRIPTION
Fix compilation error of undefined reference to 'ts::UString::toUTF8() const'